### PR TITLE
Update init and readme references to applications

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,9 +20,9 @@ Run
 cord init
 ```
 
-This command will ask you for some credentials and add them to a `.cord` file within your home directory. To run any command (other than `cord project`) you will need the `CORD_PROJECT_ID` and `CORD_PROJECT_SECRET` of the project you would like to query within. These values can be found in the [console](https://console.cord.com/applications) under your chosen project's entry.
+This command will ask you for some credentials and add them to a `.cord` file within your home directory. To run any command (other than `cord project`) you will need the `CORD_PROJECT_ID` and `CORD_PROJECT_SECRET` of the project you would like to query within. These values can be found in the [console](https://console.cord.com/projects) under your chosen project's entry.
 
-The `CORD_CUSTOMER_ID` and `CORD_CUSTOMER_SECRET` are only needed if you need app management commands, which you probably don't. If you do, they can be found in the [console](https://console.cord.com/applications), under `View application management credentials`.
+The `CORD_CUSTOMER_ID` and `CORD_CUSTOMER_SECRET` are only needed if you need project management commands, which you probably don't. If you do, you'll have to be on the premium plan they can be found in [console](https://console.cord.com/settings/customer), under `Your Account API keys`.
 
 If you already have a `.cord` file and would like to re-configure your variables, running `cord init` will default to the existing values.
 

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -9,7 +9,7 @@ async function initializeCord() {
     /*no-op. probably just doesn't exist yet*/
   });
   console.log(
-    'All of the following can be found at https://console.cord.com/applications',
+    'All of the following can be found at https://console.cord.com/projects',
   );
   const questions: QuestionCollection<{
     CORD_PROJECT_ID: string;
@@ -45,7 +45,7 @@ async function initializeCord() {
     {
       name: 'requiresAppCommands',
       message:
-        'Will you be running any project management commands? (You will need extra credentials):',
+        'Will you be running any project management commands? (You will need extra credentials available on the Premium plan):',
       type: 'confirm',
       default: false,
     },
@@ -53,7 +53,7 @@ async function initializeCord() {
       name: 'CORD_CUSTOMER_ID',
       default: defaultAnswers?.CORD_CUSTOMER_ID,
       message:
-        'Find your customer ID and secret by clicking the "View application management credentials" button at the upper right of https://console.cord.com/applications. Your customer ID:',
+        'Find your customer ID and secret under the `Your Account API keys` section in https://console.cord.com/settings/customer. Your customer ID:',
       type: 'input',
       when: (currentAnswers) => currentAnswers.requiresAppCommands,
     },


### PR DESCRIPTION
Summary:
Updated instructions on how to find customer ID
and secret which are only available when on the
premium plan.

Noticed links are still pointing to /applications
which get redirected anyway but easy to update.